### PR TITLE
Added support for wakatime

### DIFF
--- a/.github/workflows/github-stats.yaml
+++ b/.github/workflows/github-stats.yaml
@@ -1,0 +1,16 @@
+name: Waka Readme
+
+on:
+  schedule:
+    # Runs at 12am IST
+    - cron: '30 18 * * *'
+  workflow_dispatch:
+jobs:
+  update-readme:
+    name: Update Readme with Metrics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anmol098/waka-readme-stats@master
+        with:
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
-# Hi there 👋
+<h1 align="center">Hi there, I'm Jennifer</a> <img src="https://user-images.githubusercontent.com/64318469/176737130-33ef105d-385a-43e4-a68e-33ac3f19ab12.gif" height="32" /></h1>
 
-[![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=candiedcode&show_icons=true&theme=radical)](https://github.com/anuraghazra/github-readme-stats)
 
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=candiedcode&layout=compact&theme=radical)](https://github.com/anuraghazra/github-readme-stats)
+[![Typing SVG](https://readme-typing-svg.herokuapp.com?duration=3000&lines=Architect;Cloud+Native+Engineer;Software+Leader;Problem+Solver;Technology+Enthusiast)](https://git.io/typing-svg)
 
-[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=DenverCoder1)](https://git.io/streak-stats)
+[![Twitter Follow](https://img.shields.io/twitter/follow/candiedcode?label=Follow)](https://twitter.com/intent/follow?screen_name=candiedcode)
+[![Linkedin: jcwagenberg](https://img.shields.io/badge/-candiedcode-blue?style=flat-square&logo=Linkedin&logoColor=white&link=https://www.linkedin.com/in/jcwagenberg/)](https://www.linkedin.com/in/jcwagenberg/)
+![GitHub followers](https://img.shields.io/github/followers/candiedcode?label=Follow&style=social)
+![](https://visitor-badge.glitch.me/badge?page_id=candiedcode.candiedcode)
+[![website](https://img.shields.io/badge/Website-46a2f1.svg?&style=flat-square&logo=Google-Chrome&logoColor=white&link=https://anmolsingh.me/)](https://dev.to/candiedcode)
+
+<br>
+<h2>🏆 Github Profile Trophies and Stats</h2>
+
+<p align="left">
+  <img alig src="https://github-profile-trophy.vercel.app/?username=CandiedCode&column=8&rank=SSS,SS,S,AAA,AA,A,SECRET&theme=gruvbox&no-frame=true" />
+</p>
+<br>
+
+---
+<!--START_SECTION:waka-->
+
+<!--END_SECTION:waka-->
+---
+<p float="center">
+  <img alig src="https://github-readme-streak-stats.herokuapp.com?user=CandiedCode&theme=neon-palenight&hide_border=true"  width="410"/>  
+  <img src="https://github-readme-stats.vercel.app/api?username=CandiedCode&show_icons=true&theme=gotham" alt="mayukhmali"width="410" />
+</p>


### PR DESCRIPTION
Comparing the different github stats that are available.  

I've integrated:
- wakatime.com
- github-profile-trophy.vercel.app

Note wakatime will be updated via a cron github action daily.